### PR TITLE
[fixed]Feature/issue#28 シードデータ作成方法を確立する

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -3,6 +3,6 @@ spring.datasource.url=jdbc:postgresql://db:5432/root
 spring.datasource.username=root
 spring.datasource.password=aokim
 logging.level.org.hibernate.SQL=DEBUG
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/app/src/main/resources/import.sql
+++ b/app/src/main/resources/import.sql
@@ -1,0 +1,2 @@
+INSERT INTO projects (name, icon_url, description) VALUES ('test_project', 'test_icon_url', 'test_description');
+INSERT INTO users (is_owner, project_id, icon_url, name, introduce) VALUES (true, 1, 'test_url', 'test_user', 'test_introduce');

--- a/app/src/main/resources/import.sql
+++ b/app/src/main/resources/import.sql
@@ -1,2 +1,12 @@
-INSERT INTO projects (name, icon_url, description) VALUES ('test_project', 'test_icon_url', 'test_description');
-INSERT INTO users (is_owner, project_id, icon_url, name, introduce) VALUES (true, 1, 'test_url', 'test_user', 'test_introduce');
+INSERT INTO projects (name, icon_url, description) VALUES ('test_project', 'test_icon_url', 'test_description'),('test_project2', 'test_icon_url2', 'test_description2');
+INSERT INTO users (is_owner, project_id, icon_url, name, introduce) VALUES (true, 1, 'test_url1', 'test_user1', 'test_introduce1'),(false, 1, 'test_url2', 'test_user2', 'test_introduce2'),(false, 1, 'test_url3', 'test_user3', 'test_introduce3');
+INSERT INTO project_notices (log, project_id) VALUES ('log1', 1),('log2', 1);
+INSERT INTO directories (name, project_id) VALUES ('directory1', 1),('directory2', 1);
+INSERT INTO files (name, file_url, directory_id, project_id) VALUES ('file1', 'file_url1', 1, 1),('file2', 'file_url2', 1, 1);
+INSERT INTO skills (name, count_log, user_id) VALUES ('skill1', 1, 1),('skill2', 2, 1);
+INSERT INTO rolls (name, count_log, user_id) VALUES ('roll1', 1, 1),('roll2', 2, 1);
+INSERT INTO chat_rooms (name, project_id) VALUES ('chat_room1', 1),('chat_room1', 1);
+INSERT INTO channels (name, chat_room_id, user_id) VALUES ('chat_room1', 1, 1),('chat_room2', 1, 1);
+INSERT INTO messages (text, content, user_id, chat_room_id, channel_id) VALUES ('message1', 'content1', 1, 1, 1),('message2', 'content2', 1, 1, 1);
+INSERT INTO followers (user_id, follower_id) VALUES (1, 2),(1, 3);
+INSERT INTO offers (message, scouted_user_id, user_id) VALUES ('message1', 2, 1),('message2', 3, 1);


### PR DESCRIPTION
## 概要
- #28 
## 要件
- 開発のために必要なシードデータを自動生成できるようにする

### 実施内容
- import.sqlに実装を行い、ビルドと同時にシードデータが作成されるようにしました。

## 手動テスト
- pgadminでデータ生成されているか確認を行いました。

fix #28  