### PR TITLE
[fixed] メッセージEntityにcreatedAtとupdatedAtを追加する

### DIFF
--- a/app/src/main/java/com/api/EngineerCollabo/EngineerCollaboApplication.java
+++ b/app/src/main/java/com/api/EngineerCollabo/EngineerCollaboApplication.java
@@ -2,8 +2,10 @@ package com.api.EngineerCollabo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class EngineerCollaboApplication {
 
 	public static void main(String[] args) {

--- a/app/src/main/java/com/api/EngineerCollabo/controllers/MessageController.java
+++ b/app/src/main/java/com/api/EngineerCollabo/controllers/MessageController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.CrossOrigin;
 
 import com.api.EngineerCollabo.entities.Message;
 import com.api.EngineerCollabo.entities.ResponseMessage;
@@ -18,6 +19,7 @@ import com.api.EngineerCollabo.repositories.MessageRepository;
 import com.api.EngineerCollabo.services.MessageService;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:5173")
 @RequestMapping("/messages")
 public class MessageController {
     @Autowired

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Message.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Message.java
@@ -1,4 +1,5 @@
 package com.api.EngineerCollabo.entities;
+import java.util.Date;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,9 +10,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import jakarta.persistence.EntityListeners;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "messages")
 public class Message {
     @Id
@@ -29,6 +35,14 @@ public class Message {
 
     @Column(name = "channel_id")
     private Integer channelId;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)


### PR DESCRIPTION
fix #92 