### PR TITLE
messageEntity以外にもcreatedAtとupdatedAtを追加する。 #94

### DIFF
--- a/app/src/main/java/com/api/EngineerCollabo/entities/Channel.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Channel.java
@@ -1,11 +1,17 @@
 package com.api.EngineerCollabo.entities;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,6 +23,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "channels")
 public class Channel {
     @Id
@@ -31,6 +38,14 @@ public class Channel {
 
     @Column(name = "chat_room_id")
     private Integer chatRoomId;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/ChatRoom.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/ChatRoom.java
@@ -1,7 +1,12 @@
 package com.api.EngineerCollabo.entities;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -11,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.Data;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "chat_rooms")
 public class ChatRoom {
     @Id
@@ -32,6 +39,14 @@ public class ChatRoom {
 
     @Column(name = "project_id")
     private Integer projectId;
+        
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @OneToMany(mappedBy= "chatRoom", cascade = CascadeType.ALL)
     private List<Channel> channels = new ArrayList<>();

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Directory.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Directory.java
@@ -1,11 +1,17 @@
 package com.api.EngineerCollabo.entities;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -17,6 +23,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "directories")
 public class Directory {
     @Id
@@ -28,6 +35,14 @@ public class Directory {
 
     @Column(name = "project_id")
     private Integer projectId;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "project_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/File.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/File.java
@@ -1,7 +1,14 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "files")
 public class File {
     @Id
@@ -26,6 +34,14 @@ public class File {
 
     @Column(name = "directory_id")
     private Integer directoryId;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "directory_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Follower.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Follower.java
@@ -1,21 +1,38 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.Data;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "Followers")
 public class Follower {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()    
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id")

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Member.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Member.java
@@ -1,21 +1,38 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.Data;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "members")
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id")

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Member.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Member.java
@@ -1,12 +1,7 @@
 package com.api.EngineerCollabo.entities;
 
-import java.util.Date;
-
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
@@ -26,14 +21,6 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private Date createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private Date updatedAt;
-
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id")
     private User user;

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Offer.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Offer.java
@@ -1,7 +1,14 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "offers")
 public class Offer {
     @Id
@@ -26,6 +34,14 @@ public class Offer {
 
     @Column(name = "scouted_user_id")
     private Integer scoutedUserId;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "scouted_user_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Owner.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Owner.java
@@ -1,22 +1,38 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.Data;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "owners")
 public class Owner {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id")

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Project.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Project.java
@@ -4,9 +4,14 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,6 +25,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "Projects", indexes = { @Index(name = "user_name_index", columnList = "name") })
 public class Project {
     @Id
@@ -37,6 +43,14 @@ public class Project {
 
     @Column(name = "deadline", nullable = true, columnDefinition = "DATE")
     private Date deadline;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     // @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     // private List<User> users = new ArrayList<>();

--- a/app/src/main/java/com/api/EngineerCollabo/entities/ProjectNotice.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/ProjectNotice.java
@@ -1,7 +1,14 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "project_notices")
 public class ProjectNotice {
     @Id
@@ -23,7 +31,15 @@ public class ProjectNotice {
 
     @Column(name = "project_id")
     private Integer projectId;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
 
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
+    
     @ManyToOne()
     @JoinColumn(name = "project_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)
     private Project project;

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Role.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Role.java
@@ -1,7 +1,14 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "roles")
 public class Role {
     @Id
@@ -26,6 +34,14 @@ public class Role {
 
     @Column(name = "user_id")
     private Integer userId;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/Skill.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/Skill.java
@@ -1,7 +1,14 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "skills")
 public class Skill {
     @Id
@@ -26,6 +34,14 @@ public class Skill {
 
     @Column(name = "user_id")
     private Integer userId;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/User.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/User.java
@@ -98,7 +98,7 @@ public class User {
     private List<Follower> followers = new ArrayList<>();
 
     @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(name = "members", joinColumns = @JoinColumn(name = "users_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "project_id", referencedColumnName = "id"))
+    @JoinTable(name = "members", joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "project_id", referencedColumnName = "id"))
     private List<Member> members = new ArrayList<>();
 
     @ManyToMany(fetch = FetchType.EAGER)

--- a/app/src/main/java/com/api/EngineerCollabo/entities/User.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/User.java
@@ -1,11 +1,17 @@
 package com.api.EngineerCollabo.entities;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,6 +27,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "Users", indexes = { @Index(name = "project_name_index", columnList = "name") })
 public class User {
     @Id
@@ -54,6 +61,14 @@ public class User {
     // @JoinColumn(name = "project_id", nullable = false, referencedColumnName =
     // "id")
     // private Project project;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserNotice> userNotices = new ArrayList<>();

--- a/app/src/main/java/com/api/EngineerCollabo/entities/UserNotice.java
+++ b/app/src/main/java/com/api/EngineerCollabo/entities/UserNotice.java
@@ -1,7 +1,14 @@
 package com.api.EngineerCollabo.entities;
 
+import java.util.Date;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,6 +19,7 @@ import lombok.Data;
 
 @Data
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "user_notices")
 public class UserNotice {
     @Id
@@ -23,6 +31,14 @@ public class UserNotice {
 
     @Column(name = "user_id")
     private Integer userId;
+    
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private Date createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private Date updatedAt;
 
     @ManyToOne()
     @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id", insertable = false, updatable = false)

--- a/app/src/main/resources/import.sql
+++ b/app/src/main/resources/import.sql
@@ -1,24 +1,23 @@
-INSERT INTO projects (name, icon_url, description, deadline) VALUES ('test_project', 'test_icon_url', 'test_description', '2014-01-01'),('test_project2', 'test_icon_url2', 'test_description2', '2014-01-02');
-
-INSERT INTO users (is_owner, icon_url, name, introduce, password, email) VALUES (true, 'test_url1', 'test_user1', 'test_introduce1', 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb', 'a'),(false, 'test_url2', 'test_user2', 'test_introduce2', '$2a$10$JwMUEwh6hiB/NAMZ5VVOEOSGsdF8Uri4dldDwQI3Mm8R0U69zGFIK', 'test2@gmail.com'),(false, 'test_url3', 'test_user3', 'test_introduce3', '$2a$10$MkIFq60lMNHtQdJPaSXiLOCpopZV2NahWktyGKrQBPm.kgikRV1ZO', 'test3@gmail.com');
+INSERT INTO projects (name, icon_url, description, deadline, created_at, updated_at) VALUES ('test_project', 'test_icon_url', 'test_description', '2014-01-01', date('2024/04/21'), date('2024/04/21')),('test_project2', 'test_icon_url2', 'test_description2', '2014-01-02', date('2024/04/21'), date('2024/04/21'));
+INSERT INTO users (is_owner, icon_url, name, introduce, password, email, created_at, updated_at) VALUES (true, 'test_url1', 'test_user1', 'test_introduce1', 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb', 'a', date('2024/04/21'), date('2024/04/21')),(false, 'test_url2', 'test_user2', 'test_introduce2', '$2a$10$JwMUEwh6hiB/NAMZ5VVOEOSGsdF8Uri4dldDwQI3Mm8R0U69zGFIK', 'test2@gmail.com', date('2024/04/21'), date('2024/04/21')),(false, 'test_url3', 'test_user3', 'test_introduce3', '$2a$10$MkIFq60lMNHtQdJPaSXiLOCpopZV2NahWktyGKrQBPm.kgikRV1ZO', 'test3@gmail.com', date('2024/04/21'), date('2024/04/21'));
 -- userの暗号化する前のpasswordは「a」,「password2」,「password3」
 INSERT INTO members (project_id, user_id) VALUES (1, 1),(1, 2),(1, 3);
-INSERT INTO project_notices (log, project_id) VALUES ('log1', 1),('log2', 1);
-INSERT INTO user_notices (log, user_id) VALUES ('log1', 1),('log2', 1);
-INSERT INTO directories (name, project_id) VALUES ('directory1', 1),('directory2', 1);
--- INSERT INTO files (name, file_url, directory_id, project_id) VALUES ('file1', 'file_url1', 1, 1),('file2', 'file_url2', 1, 1);
-INSERT INTO files (name, file_url, directory_id) VALUES ('file1', 'file_url1', 1),('file2', 'file_url2', 1);
-INSERT INTO skills (name, count_log, user_id) VALUES ('skill1', 1, 1),('skill2', 2, 1);
-INSERT INTO roles (name, count_log, user_id) VALUES ('role1', 1, 1),('role2', 2, 1);
-INSERT INTO chat_rooms (name, project_id) VALUES ('chat_room1', 1),('chat_room1', 1);
--- INSERT INTO channels (name, chat_room_id, user_id) VALUES ('chat_room1', 1, 1),('chat_room2', 1, 1);
-INSERT INTO channels (name, chat_room_id, user_id) VALUES ('channel1', 1, 1),('channel2', 1, 1);
--- INSERT INTO messages (text, content, user_id, chat_room_id, channel_id) VALUES ('message1', 'content1', 1, 1, 1),('message2', 'content2', 1, 1, 1);
+INSERT INTO project_notices (log, project_id, created_at, updated_at) VALUES ('log1', 1, date('2024/04/21'), date('2024/04/21')),('log2', 1, date('2024/04/21'), date('2024/04/21'));
+INSERT INTO user_notices (log, user_id, created_at, updated_at) VALUES ('log1', 1, date('2024/04/21'), date('2024/04/21')),('log2', 1, date('2024/04/21'), date('2024/04/21'));
+INSERT INTO directories (name, project_id, created_at, updated_at) VALUES ('directory1', 1, date('2024/04/21'), date('2024/04/21')),('directory2', 1, date('2024/04/21'), date('2024/04/21'));
+-- INSERT INTO files (name, file_url, directory_id, project_id, created_at, updated_at) VALUES ('file1', 'file_url1', 1, 1),('file2', 'file_url2', 1, 1);
+INSERT INTO files (name, file_url, directory_id, created_at, updated_at) VALUES ('file1', 'file_url1', 1, date('2024/04/21'), date('2024/04/21')),('file2', 'file_url2', 1, date('2024/04/21'), date('2024/04/21'));
+INSERT INTO skills (name, count_log, user_id, created_at, updated_at) VALUES ('skill1', 1, 1, date('2024/04/21'), date('2024/04/21')),('skill2', 2, 1, date('2024/04/21'), date('2024/04/21'));
+INSERT INTO roles (name, count_log, user_id, created_at, updated_at) VALUES ('role1', 1, 1, date('2024/04/21'), date('2024/04/21')),('role2', 2, 1, date('2024/04/21'), date('2024/04/21'));
+INSERT INTO chat_rooms (name, project_id, created_at, updated_at) VALUES ('chat_room1', 1, date('2024/04/21'), date('2024/04/21')),('chat_room1', 1, date('2024/04/21'), date('2024/04/21'));
+-- INSERT INTO channels (name, chat_room_id, user_id, created_at, updated_at) VALUES ('chat_room1', 1, 1),('chat_room2', 1, 1);
+INSERT INTO channels (name, chat_room_id, user_id, created_at, updated_at) VALUES ('channel1', 1, 1, date('2024/04/21'), date('2024/04/21')),('channel2', 1, 1, date('2024/04/21'), date('2024/04/21'));
+-- INSERT INTO messages (text, content, user_id, chat_room_id, channel_id, created_at, updated_at) VALUES ('message1', 'content1', 1, 1, 1),('message2', 'content2', 1, 1, 1);
 INSERT INTO messages (text, content, user_id, channel_id, created_at, updated_at) VALUES ('message1', 'content1', 1, 1, date('2024/02/10'), date('2024/02/11')),('message2', 'content2', 1, 1, date('2024/01/15'), date('2024/01/20'));
-INSERT INTO followers (user_id, follower_id) VALUES (1, 2),(1, 3);
--- INSERT INTO members (project_id, user_id) VALUES (1, 1), (1,2)
-INSERT INTO offers (message, scouted_user_id, user_id) VALUES ('message1', 2, 1),('message2', 3, 1);
-INSERT INTO owners (project_id, user_id) VALUES (1, 1),(1, 2);
+INSERT INTO followers (user_id, follower_id, created_at, updated_at) VALUES (1, 2, date('2024/04/21'), date('2024/04/21')),(1, 3, date('2024/04/21'), date('2024/04/21'));
+-- INSERT INTO members (project_id, user_id, created_at, updated_at) VALUES (1, 1), (1,2)
+INSERT INTO offers (message, scouted_user_id, user_id, created_at, updated_at) VALUES ('message1', 2, 1, date('2024/04/21'), date('2024/04/21')),('message2', 3, 1, date('2024/04/21'), date('2024/04/21'));
+INSERT INTO owners (project_id, user_id, created_at, updated_at) VALUES (1, 1, date('2024/04/21'), date('2024/04/21')),(1, 2, date('2024/04/21'), date('2024/04/21'));
 INSERT INTO projects_users (project_id, users_id) VALUES (1, 1),(1, 2),(2, 1);
 INSERT INTO operations (project_id, log, created_at, updated_at) VALUES (1, 'ログ1', date('2024/01/15'), date('2024/01/20')),(1, 'ログ2', date('2024/02/15'), date('2024/02/20')),(2, 'ログ3', date('2024/03/15'), date('2024/03/20'));
 INSERT INTO tasks (in_charge_user_id, is_done, project_id, deadline, name, description, created_at, updated_at) VALUES (1, false, 1, date('2024/10/15'), 'バックエンド実装', 'バックエンドの実装をJavaで行う', date('2024/01/20'), date('2024/01/20')),(2, true, 1, date('2024/10/16'), 'フロントエンド実装', 'フロントエンドの実装をVueで行う', date('2024/01/20'), date('2024/01/20'));


### PR DESCRIPTION
fix #94

### やったこと

以下のテーブルにcreated_atとupdated_atを追加

- followers
- chat_rooms
- directories
- files
- members
- user_notices
- owners
- project_notices
- roles
- skills
- channels
- users
- projects
- offers

シードにcreated_atとupdated_atを追加

### やらないこと

下記テーブルにcreated_atとupdated_atを追加すること

交差テーブル
- projects_users
(一旦中間テーブルは除外)

不要になったmembersテーブルまわりの削除

修正済み

- operations
- messages
- tasks